### PR TITLE
Add TTL line to piggyback files

### DIFF
--- a/agents/plugins/cmk_mqtt_pighgyback.py
+++ b/agents/plugins/cmk_mqtt_pighgyback.py
@@ -3,6 +3,7 @@ import sys
 import time
 import argparse
 import json
+import os
 import paho.mqtt.client as mqtt
 
 def on_message(client, userdata, msg):
@@ -15,7 +16,9 @@ def on_message(client, userdata, msg):
             return
         piggy_file = f"/var/lib/check_mk_agent/spool/piggyback/{hostname}/mqtt_status"
         os.makedirs(os.path.dirname(piggy_file), exist_ok=True)
+        ttl = userdata.get("ttl", 60)
         with open(piggy_file, "w") as f:
+            print(ttl, file=f)
             print("<<<mqtt_status>>>", file=f)
             print(json.dumps(data), file=f)
     except Exception as e:
@@ -27,9 +30,10 @@ def main():
     parser.add_argument("--mqtt_host", required=True)
     parser.add_argument("--mqtt_port", type=int, default=1883)
     parser.add_argument("--mqtt_topics", required=True)  # Kommagetrennte Liste
+    parser.add_argument("--ttl", type=int, default=60)
     args = parser.parse_args()
 
-    client = mqtt.Client()
+    client = mqtt.Client(userdata={"ttl": args.ttl})
     client.on_message = on_message
     client.connect(args.mqtt_host, args.mqtt_port, 60)
 


### PR DESCRIPTION
## Summary
- include configurable TTL when writing piggyback spool files

## Testing
- `python -m py_compile agents/plugins/cmk_mqtt_pighgyback.py`
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_6899b24d3d588333ac2b38f17bffec27