### PR TITLE
Document paho-mqtt dependency

### DIFF
--- a/info
+++ b/info
@@ -4,3 +4,4 @@ packaged_at: 2025-07-08
 description: "MQTT Piggyback Plugin for Checkmk"
 author: Jens Constroffer
 compatible: 2.1, 2.2
+requires: paho-mqtt (muss auf dem Agent-System installiert sein)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+paho-mqtt


### PR DESCRIPTION
## Summary
- add `paho-mqtt` to project requirements
- document that `paho-mqtt` must be installed on the agent system

## Testing
- `python -m py_compile agents/plugins/cmk_mqtt_pighgyback.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899b23f309c8333a4f2bcc2d15a6411