### PR TITLE
Add MQTT status check plugin

### DIFF
--- a/checks/mqtt_status.py
+++ b/checks/mqtt_status.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Checkmk check plugin for MQTT status."""
+
+import json
+from typing import Any, Mapping
+
+from .agent_based_api.v1 import (
+    Metric,
+    Result,
+    Service,
+    State,
+    register,
+)
+
+
+def parse_mqtt_status(string_table):
+    """Parse JSON payload from <<<mqtt_status>>> section."""
+    if not string_table:
+        return {}
+    line = " ".join(string_table[0])
+    try:
+        return json.loads(line)
+    except json.JSONDecodeError:
+        return {}
+
+
+register.agent_section(
+    name="mqtt_status",
+    parse_function=parse_mqtt_status,
+)
+
+
+def discovery_mqtt_status(section: Mapping[str, Any]):
+    if section:
+        yield Service()
+
+
+def check_mqtt_status(params: Mapping[str, Any], section: Mapping[str, Any]):
+    status = str(section.get("status", "UNKNOWN"))
+    metric_value = section.get("metric")
+
+    state_map = {
+        "OK": State.OK,
+        "WARN": State.WARN,
+        "CRIT": State.CRIT,
+    }
+    state = state_map.get(status.upper(), State.UNKNOWN)
+    summary = f"Status {status}"
+
+    if metric_value is not None:
+        metric_val = float(metric_value)
+        warn, crit = params.get("metric_levels", (None, None))
+        yield Metric("metric", metric_val, levels=(warn, crit))
+        summary += f", metric {metric_val}"
+        if crit is not None and metric_val >= crit:
+            state = State.CRIT
+        elif warn is not None and metric_val >= warn and state is State.OK:
+            state = State.WARN
+
+    yield Result(state=state, summary=summary)
+
+
+register.check_plugin(
+    name="mqtt_status",
+    service_name="MQTT Status",
+    discovery_function=discovery_mqtt_status,
+    check_function=check_mqtt_status,
+    check_default_parameters={"metric_levels": (80.0, 90.0)},
+    check_ruleset_name="mqtt_status",
+)

--- a/manifest
+++ b/manifest
@@ -13,3 +13,5 @@ files             = agent_based, web, gui, agents, plugins
 [files]
 agents/cmk_mqtt_piggyback.py
 web/plugins/wato/cmk_mqtt_piggyback.py
+checks/mqtt_status.py
+web/plugins/wato/mqtt_status.py

--- a/web/plugins/wato/mqtt_status.py
+++ b/web/plugins/wato/mqtt_status.py
@@ -1,0 +1,36 @@
+# WATO rule for MQTT status check
+
+from cmk.gui.i18n import _
+from cmk.gui.valuespec import Dictionary, Float, Tuple
+from cmk.gui.plugins.wato import (
+    CheckParameterRulespecWithoutItem,
+    RulespecGroupCheckParametersApplications,
+    rulespec_registry,
+)
+
+
+def _parameter_valuespec_mqtt_status():
+    return Dictionary(
+        elements=[
+            (
+                "metric_levels",
+                Tuple(
+                    title=_("Metric levels"),
+                    elements=[
+                        Float(title=_("Warning at"), default_value=80.0),
+                        Float(title=_("Critical at"), default_value=90.0),
+                    ],
+                ),
+            ),
+        ],
+    )
+
+
+rulespec_registry.register(
+    CheckParameterRulespecWithoutItem(
+        check_group_name="mqtt_status",
+        group=RulespecGroupCheckParametersApplications,
+        match_type="dict",
+        parameter_valuespec=_parameter_valuespec_mqtt_status,
+    )
+)


### PR DESCRIPTION
## Summary
- Add MQTT status check plugin parsing `mqtt_status` agent sections and reporting status and metric performance data
- Provide WATO rule for configuring metric thresholds

## Testing
- `python -m py_compile checks/mqtt_status.py web/plugins/wato/mqtt_status.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899b2291d1083339c7b8ee5f74bc9e3