### PR TITLE
Add missing os import for MQTT piggyback plugin

### DIFF
--- a/agents/plugins/cmk_mqtt_pighgyback.py
+++ b/agents/plugins/cmk_mqtt_pighgyback.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import os
 import sys
 import time
 import argparse


### PR DESCRIPTION
## Summary
- import the os module in the MQTT piggyback plugin to enable directory creation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899b1f548788333b15a8952b7832d8e