### PR TITLE
Add helper script for MKP packaging and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,19 @@ Dieses Repository enthält ein Beispiel für eine Checkmk-Erweiterung, die Piggy
    ```bash
    cmk -v pack mkp
    ```
-   Alternativ kann das `mkp`-Werkzeug genutzt werden:
+   Alternativ kann das `mkp`-Werkzeug genutzt werden. Damit `mkp` die
+   Dateien innerhalb dieses Repositorys findet, muss das Wurzelverzeichnis
+   angegeben werden:
    ```bash
-   mkp package
+   mkp package -d . manifest
    ```
-   Nach dem Bauen befindet sich die Datei `cmk_mqtt_piggyback-<version>.mkp` im aktuellen Verzeichnis.
+   Zur Vereinfachung steht zusätzlich das Skript `build_mkp.sh`
+   zur Verfügung:
+   ```bash
+   ./build_mkp.sh
+   ```
+   Nach dem Bauen befindet sich die Datei `cmk_mqtt_piggyback-<version>.mkp`
+   im aktuellen Verzeichnis.
 
 ## Installation auf dem Checkmk-Server
 
@@ -30,10 +38,11 @@ Dieses Repository enthält ein Beispiel für eine Checkmk-Erweiterung, die Piggy
 
 ## Installation auf dem Checkmk-Agenten
 
-1. Nach der Installation enthält das Paket ein Agenten-Plugin unter `agents/plugins/cmk_mqtt_pighgyback.py`.
+1. Nach der Installation enthält das Paket ein Agenten-Plugin unter `agents/plugins/cmk_mqtt_piggyback.py`.
 2. Kopieren Sie diese Datei auf den Zielhost nach `/usr/lib/check_mk_agent/plugins/` (Linux).
 3. Machen Sie das Skript ausführbar:
    ```bash
-   chmod +x /usr/lib/check_mk_agent/plugins/cmk_mqtt_pighgyback.py
+   chmod +x /usr/lib/check_mk_agent/plugins/cmk_mqtt_piggyback.py
    ```
-4. Führen Sie einen Agenten-Update (`check_mk_agent`) aus, um die Piggyback-Daten zu prüfen.
+4. Führen Sie einen Agenten-Update (`check_mk_agent`) aus, um die
+   Piggyback-Daten zu prüfen.

--- a/build_mkp.sh
+++ b/build_mkp.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build MKP package using the manifest in this repository.
+#
+# The mkp tool expects the project files to live beneath the given
+# directory. By default it searches the Checkmk site directories, which
+# would cause a "Cannot stat" error if the files are only present in the
+# repository. We therefore explicitly point mkp to the current
+# repository root so that the files from the agents/, checks/ and web/
+# folders are found correctly.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+mkp package -d "$SCRIPT_DIR" "$SCRIPT_DIR/manifest"


### PR DESCRIPTION
## Summary
- Add `build_mkp.sh` helper script to invoke `mkp package` with repository root
- Clarify packaging instructions in README and fix typos

## Testing
- `python -m py_compile checks/mqtt_status.py agents/plugins/cmk_mqtt_piggyback.py web/plugins/wato/agent_mqtt_piggyback.py web/plugins/wato/mqtt_status.py`
- `bash -n build_mkp.sh`


------
https://chatgpt.com/codex/tasks/task_e_6899e7f0e4b08333b192af99a421b8dc