### PR TITLE
Correct mkp packaging invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Dieses Repository enthält ein Beispiel für eine Checkmk-Erweiterung, die Piggy
    Dateien innerhalb dieses Repositorys findet, muss das Wurzelverzeichnis
    angegeben werden:
    ```bash
-   mkp package -d . manifest
+   mkp -d . package manifest
    ```
    Zur Vereinfachung steht zusätzlich das Skript `build_mkp.sh`
    zur Verfügung:

--- a/build_mkp.sh
+++ b/build_mkp.sh
@@ -11,4 +11,6 @@ set -euo pipefail
 # folders are found correctly.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-mkp package -d "$SCRIPT_DIR" "$SCRIPT_DIR/manifest"
+# Older versions of Checkmk expect the -d option *before* the subcommand.
+# Use the correct order so that the repository root is respected.
+mkp -d "$SCRIPT_DIR" package "$SCRIPT_DIR/manifest"


### PR DESCRIPTION
## Summary
- fix build_mkp.sh to pass -d before `package`
- document updated mkp command in README

## Testing
- `python -m py_compile checks/mqtt_status.py agents/plugins/cmk_mqtt_piggyback.py web/plugins/wato/agent_mqtt_piggyback.py web/plugins/wato/mqtt_status.py`
- `shellcheck build_mkp.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899e9817ff88333a193d85d7b6eaeaf