### PR TITLE
Handle legacy and modern mkp -d orderings

### DIFF
--- a/build_mkp.sh
+++ b/build_mkp.sh
@@ -12,5 +12,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Older versions of Checkmk expect the -d option *before* the subcommand.
-# Use the correct order so that the repository root is respected.
-mkp -d "$SCRIPT_DIR" package "$SCRIPT_DIR/manifest"
+# Newer versions moved it behind the subcommand. Try the modern syntax first
+# and fall back to the legacy order for older Checkmk releases.
+if ! mkp package -d "$SCRIPT_DIR" "$SCRIPT_DIR/manifest"; then
+    mkp -d "$SCRIPT_DIR" package "$SCRIPT_DIR/manifest"
+fi


### PR DESCRIPTION
## Summary
- make build script support both new and old `mkp` `-d` option positions

## Testing
- `./build_mkp.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899f6605a748333b858652b87d1835d