### PR TITLE
Support new mkp behavior in build script

### DIFF
--- a/build_mkp.sh
+++ b/build_mkp.sh
@@ -9,11 +9,16 @@ set -euo pipefail
 # repository. We therefore explicitly point mkp to the current
 # repository root so that the files from the agents/, checks/ and web/
 # folders are found correctly.
-
+#
+# Depending on the Checkmk version, the -d option may have to be supplied
+# in different ways or not at all. We try the supported variants in order,
+# stopping once one succeeds.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Older versions of Checkmk expect the -d option *before* the subcommand.
-# Newer versions moved it behind the subcommand. Try the modern syntax first
-# and fall back to the legacy order for older Checkmk releases.
-if ! mkp package -d "$SCRIPT_DIR" "$SCRIPT_DIR/manifest"; then
+
+if mkp package -d "$SCRIPT_DIR" "$SCRIPT_DIR/manifest"; then
+    :
+elif mkp package "$SCRIPT_DIR/manifest"; then
+    :
+else
     mkp -d "$SCRIPT_DIR" package "$SCRIPT_DIR/manifest"
 fi


### PR DESCRIPTION
## Summary
- try `mkp package -d` first to locate repository files
- fall back to other invocation styles for broader version coverage

## Testing
- `bash -n build_mkp.sh`

------
https://chatgpt.com/codex/tasks/task_e_6899f8c05e548333afd74c2e0cf39873