### PR TITLE
Add alternative mkp directory argument

### DIFF
--- a/build_mkp.sh
+++ b/build_mkp.sh
@@ -19,6 +19,8 @@ if mkp package "$SCRIPT_DIR/manifest"; then
     :
 elif mkp package -d "$SCRIPT_DIR" "$SCRIPT_DIR/manifest"; then
     :
+elif mkp package "$SCRIPT_DIR/manifest" -d "$SCRIPT_DIR"; then
+    :
 else
     mkp -d "$SCRIPT_DIR" package "$SCRIPT_DIR/manifest"
 fi


### PR DESCRIPTION
## Summary
- make build script more robust to different mkp versions by trying `mkp package <manifest> -d <dir>`

## Testing
- `./build_mkp.sh` *(fails: command not found: mkp)*

------
https://chatgpt.com/codex/tasks/task_e_6899fc6907d48333a93c3f1e8e50c371